### PR TITLE
Fix flag description hyphen incorrectly styled

### DIFF
--- a/coloredcobra.go
+++ b/coloredcobra.go
@@ -219,7 +219,7 @@ func Init(cfg *Config) {
 
 				// Styling short and full flags (-f, --flag)
 				if cf != nil {
-					re := regexp.MustCompile(`(--?\S+)`)
+					re := regexp.MustCompile(`\s(--?\S+)`)
 					for _, flag := range re.FindAllString(lines[k], 2) {
 						lines[k] = strings.Replace(lines[k], flag, cf.Sprint(flag), 1)
 					}


### PR DESCRIPTION
When a flag description contains a hyphen, the flag style is incorrectly applied. For example, see the description of the `--config` flag:
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/6e615c2f-9e54-42cd-9535-62d1a59cd63d">

This PR changes the flag regex to only match flags when the hyphen is preceded by a space.

Here's the same example after the fix:
<img width="1027" alt="image" src="https://github.com/user-attachments/assets/8b962691-3225-4f27-ad81-117b223dfd2f">

Fixes #2